### PR TITLE
need to pin focal builds to old gclient version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,13 +81,9 @@ RUN \
 RUN \
  echo "**** grab source ****" && \
  mkdir -p /gclient && \
- if [ -z ${GCLIENT_RELEASE+x} ]; then \
-	GCLIENT_RELEASE=$(curl -sX GET "https://api.github.com/repos/linuxserver/gclient/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
  curl -o \
  /tmp/gclient.tar.gz -L \
-	"https://github.com/linuxserver/gclient/archive/${GCLIENT_RELEASE}.tar.gz" && \
+	"https://github.com/linuxserver/gclient/archive/1.1.2.tar.gz" && \
  tar xf \
  /tmp/gclient.tar.gz -C \
 	/gclient/ --strip-components=1

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -81,13 +81,9 @@ RUN \
 RUN \
  echo "**** grab source ****" && \
  mkdir -p /gclient && \
- if [ -z ${GCLIENT_RELEASE+x} ]; then \
-	GCLIENT_RELEASE=$(curl -sX GET "https://api.github.com/repos/linuxserver/gclient/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
  curl -o \
  /tmp/gclient.tar.gz -L \
-	"https://github.com/linuxserver/gclient/archive/${GCLIENT_RELEASE}.tar.gz" && \
+	"https://github.com/linuxserver/gclient/archive/1.1.2.tar.gz" && \
  tar xf \
  /tmp/gclient.tar.gz -C \
 	/gclient/ --strip-components=1

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -81,13 +81,9 @@ RUN \
 RUN \
  echo "**** grab source ****" && \
  mkdir -p /gclient && \
- if [ -z ${GCLIENT_RELEASE+x} ]; then \
-	GCLIENT_RELEASE=$(curl -sX GET "https://api.github.com/repos/linuxserver/gclient/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
  curl -o \
  /tmp/gclient.tar.gz -L \
-	"https://github.com/linuxserver/gclient/archive/${GCLIENT_RELEASE}.tar.gz" && \
+	"https://github.com/linuxserver/gclient/archive/1.1.2.tar.gz" && \
  tar xf \
  /tmp/gclient.tar.gz -C \
 	/gclient/ --strip-components=1


### PR DESCRIPTION
Pin the gclient version for the focal version as the dynamic resizing only works under Jammy for Ubuntu.